### PR TITLE
Add a .gitignore rule for .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# VSCode
+.vscode


### PR DESCRIPTION
This adds a line of rule to ignore ``.vscode`` directory.
The directory is [generated by ``VSCode`` to store workspace-specific(also user-specific) configurations.](https://code.visualstudio.com/docs/editor/workspaces#_workspace-tasks-and-launch-configurations)
Since this is not a file we ever need to add to our repo, we might as well just ignore it early on to mitigate potential accidents.

Closes [#1 ](https://github.com/edamame852/opengl-sandbox/issues/2)